### PR TITLE
Optimización de la carga de imágenes

### DIFF
--- a/app/src/main/java/com/uniandes/vynilsmobile/view/AlbumFragment.kt
+++ b/app/src/main/java/com/uniandes/vynilsmobile/view/AlbumFragment.kt
@@ -44,9 +44,6 @@ class AlbumFragment : Fragment(R.layout.album_fragment) {
     ): View? {
         _binding = AlbumFragmentBinding.inflate(inflater, container, false)
 
-        val bar = (activity as AppCompatActivity).supportActionBar
-        bar?.title = getString(R.string.title_albums)
-
         progressBar = binding.progressBar
         return binding.root
     }
@@ -70,7 +67,10 @@ class AlbumFragment : Fragment(R.layout.album_fragment) {
         val activity = requireNotNull(this.activity) {
             "You can only access the viewModel after onActivityCreated()"
         }
-        activity.actionBar?.title = getString(R.string.title_albums)
+
+        val bar = (activity as AppCompatActivity).supportActionBar
+        bar?.title = getString(R.string.title_albums)
+
         viewModel = ViewModelProvider(this, AlbumViewModel.Factory(activity.application))[AlbumViewModel::class.java]
         viewModel.albums.observe(viewLifecycleOwner) { albums ->
             albumAdapter?.albums = albums

--- a/app/src/main/java/com/uniandes/vynilsmobile/view/MainActivity.kt
+++ b/app/src/main/java/com/uniandes/vynilsmobile/view/MainActivity.kt
@@ -10,6 +10,7 @@ import androidx.fragment.app.FragmentManager
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.ui.setupActionBarWithNavController
+import com.squareup.picasso.Picasso
 import com.uniandes.vynilsmobile.R
 import com.uniandes.vynilsmobile.databinding.ActivityMainBinding
 
@@ -17,8 +18,20 @@ import com.uniandes.vynilsmobile.databinding.ActivityMainBinding
 class MainActivity : AppCompatActivity() {
     private lateinit var navController: NavController
 
+    private fun initPicasso(){
+        val picasso = Picasso.Builder(this)
+            .listener { _, _, exception -> exception.printStackTrace() }
+            .indicatorsEnabled(false)
+
+        val built = picasso.build()
+        Picasso.setSingletonInstance(built)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        initPicasso()
+
         val binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
 

--- a/app/src/main/java/com/uniandes/vynilsmobile/view/adapters/AlbumsAdapter.kt
+++ b/app/src/main/java/com/uniandes/vynilsmobile/view/adapters/AlbumsAdapter.kt
@@ -6,12 +6,14 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ProgressBar
 import androidx.annotation.LayoutRes
+import androidx.core.net.toUri
 import androidx.databinding.DataBindingUtil
 import androidx.recyclerview.widget.AsyncListDiffer
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.squareup.picasso.Callback
 import com.squareup.picasso.MemoryPolicy
+import com.squareup.picasso.NetworkPolicy
 import com.squareup.picasso.Picasso
 import com.uniandes.vynilsmobile.R
 import com.uniandes.vynilsmobile.data.model.Album
@@ -40,11 +42,7 @@ class AlbumsAdapter(private val progressBar: ProgressBar, private val onItemClic
         val album = asyncListDiffer.currentList[position]
         holder.bind(album, onItemClick)
 
-        if (itemCount > 0) {
-            progressBar.visibility = View.GONE
-        } else {
-            progressBar.visibility = View.VISIBLE
-        }
+        progressBar.visibility = if(itemCount > 0) View.GONE else View.VISIBLE
     }
 
     override fun getItemCount(): Int {
@@ -69,7 +67,7 @@ class AlbumsAdapter(private val progressBar: ProgressBar, private val onItemClic
 
         private fun loadAlbumCover(imageUrl: String) {
             Picasso.get()
-                .load(imageUrl)
+                .load(imageUrl.toUri())
                 .placeholder(R.drawable.ic_baseline_album_24)
                 .error(R.drawable.ic_baseline_android_24)
                 .fit()
@@ -80,7 +78,24 @@ class AlbumsAdapter(private val progressBar: ProgressBar, private val onItemClic
                         return
                     }
                     override fun onError(e: Exception?) {
-                        Log.e("Picasso Error", "Error al cargar la imagen: ${e?.message}")
+                       Picasso.get()
+                            .load(imageUrl)
+                            .placeholder(R.drawable.ic_baseline_album_24)
+                            .error(R.drawable.ic_baseline_android_24)
+                            .fit()
+                            .centerCrop()
+                            .memoryPolicy(MemoryPolicy.NO_CACHE,MemoryPolicy.NO_STORE)
+                            .networkPolicy(NetworkPolicy.NO_CACHE, NetworkPolicy.NO_STORE)
+                            .into(viewDataBinding.imageView1, object : Callback {
+                                override fun onSuccess() {
+                                    return
+                                }
+                                override fun onError(e: Exception?) {
+                                    Log.e("Picasso Error", "Error al cargar la imagen: ${e?.message}")
+                                    viewDataBinding.imageView1.setImageResource(R.drawable.ic_baseline_android_24)
+                                    e?.printStackTrace()
+                                }
+                            })
                         return
                     }
                 })

--- a/app/src/main/java/com/uniandes/vynilsmobile/view/adapters/AlbumsAdapter.kt
+++ b/app/src/main/java/com/uniandes/vynilsmobile/view/adapters/AlbumsAdapter.kt
@@ -11,6 +11,7 @@ import androidx.recyclerview.widget.AsyncListDiffer
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.squareup.picasso.Callback
+import com.squareup.picasso.MemoryPolicy
 import com.squareup.picasso.Picasso
 import com.uniandes.vynilsmobile.R
 import com.uniandes.vynilsmobile.data.model.Album
@@ -44,8 +45,6 @@ class AlbumsAdapter(private val progressBar: ProgressBar, private val onItemClic
         } else {
             progressBar.visibility = View.VISIBLE
         }
-
-        holder.loadAlbumCover(album.cover)
     }
 
     override fun getItemCount(): Int {
@@ -65,20 +64,21 @@ class AlbumsAdapter(private val progressBar: ProgressBar, private val onItemClic
             viewDataBinding.root.setOnClickListener {
                 onItemClick(album)
             }
+            loadAlbumCover(album.cover)
         }
 
-        fun loadAlbumCover(imageUrl: String) {
+        private fun loadAlbumCover(imageUrl: String) {
             Picasso.get()
                 .load(imageUrl)
                 .placeholder(R.drawable.ic_baseline_album_24)
                 .error(R.drawable.ic_baseline_android_24)
                 .fit()
                 .centerCrop()
+                .memoryPolicy(MemoryPolicy.NO_CACHE)
                 .into(viewDataBinding.imageView1, object : Callback {
                     override fun onSuccess() {
                         return
                     }
-
                     override fun onError(e: Exception?) {
                         Log.e("Picasso Error", "Error al cargar la imagen: ${e?.message}")
                         return


### PR DESCRIPTION
Para solucionar el problema de recuperar las imágenes de la memoria cacheada, se utilizó la función "memoryPolicy()" con la opción NO_CACHE para evitar buscar imágenes en la memoria. Quedó el siguiente flujo App -> Disk -> Server